### PR TITLE
Fixes TypeScript in Cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "supportFile": "cypress/support/index.ts"
+}

--- a/cypress/plugins/cy-ts-preprocessor.js
+++ b/cypress/plugins/cy-ts-preprocessor.js
@@ -1,0 +1,26 @@
+const wp = require('@cypress/webpack-preprocessor')
+
+const webpackOptions = {
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: [/node_modules/],
+        use: [
+          {
+            loader: 'ts-loader'
+          }
+        ]
+      }
+    ]
+  }
+}
+
+const options = {
+  webpackOptions
+}
+
+module.exports = wp(options)

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,17 +1,5 @@
-// ***********************************************************
-// This example plugins/index.js can be used to load plugins
-//
-// You can change the location of this file or turn off loading
-// the plugins file with the 'pluginsFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/plugins-guide
-// ***********************************************************
+const cypressTypeScriptPreprocessor = require('./cy-ts-preprocessor')
 
-// This function is called when a project is opened or re-opened (e.g. due to
-// the project's config changing)
-
-module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+module.exports = on => {
+  on('file:preprocessor', cypressTypeScriptPreprocessor)
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -24,6 +24,9 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+/**
+ * Goes to google site
+ */
 function google() {
   return cy.visit('https://google.com');
 }

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": "../node_modules",
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "angular", "angular-animate"],
+    "types": ["cypress"],
   },
   "include": [
     "**/*.ts"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^3.0.2"
+    "@bahmutov/add-typescript-to-cypress": "2.0.0",
+    "cypress": "^3.0.2",
+    "typescript": "2.9.2"
   }
 }


### PR DESCRIPTION
- point support file at typescript file
- add typescript compiler (!) and transpile config for Cypress (by using https://github.com/bahmutov/add-typescript-to-cypress)
- remove stray libraries included in `tsconfig.json` 

<img width="1280" alt="screen shot 2018-07-26 at 11 18 13 am" src="https://user-images.githubusercontent.com/2212006/43253598-9fea8f6e-90c5-11e8-94b1-645ee848ba73.png">

VSCode IntelliSense is working for custom commands

![custom-command](https://user-images.githubusercontent.com/2212006/43253555-8c6ec6c6-90c5-11e8-985d-f1c049c1b29f.jpeg)
